### PR TITLE
refactor to use connection string instead of lots of github secrets

### DIFF
--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
 env:
+  AZURE_APP_CONFIG_CONNECTION_STRING: ${{ secrets.AZURE_APP_CONFIG_CONNECTION_STRING }}
   AZURE_ENVIRONMENT_NAME: ${{ secrets.AZURE_ENVIRONMENT_NAME }}
   AZURE_DATA_LAKE: ${{ secrets.AZURE_DATA_LAKE }}
   AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
@@ -36,7 +37,7 @@ jobs:
       - name: export environment variables
         run: |
           python -c "from datascience_core.config import Config; Config().set_default_variables()')"
-          
+
       - name: Run test suite
         run: |
           pytest datadayessentials 

--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -32,7 +32,11 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
-          python initialise_core.py
+
+      - name: export environment variables
+        run: |
+          python -c "from datascience_core.config import Config; Config().set_default_variables()')"
+          
       - name: Run test suite
         run: |
           pytest datadayessentials 

--- a/.github/workflows/on_merge.yaml
+++ b/.github/workflows/on_merge.yaml
@@ -1,10 +1,13 @@
 name: Increment version
-on:
+on: 
+  #trigger on workflow dispatch or pull request type closed on branch main
+  workflow_dispatch:
   pull_request:
     types:
       - closed
     branches:
       - main
+
 #:
 jobs:
   determine_version_update_type:

--- a/databricks/general_cluster_setup.sh
+++ b/databricks/general_cluster_setup.sh
@@ -16,7 +16,7 @@ COMMAND="pip install git+https://$TOKEN@github.com/Carfinance247/datadayessentia
 eval "$COMMAND"
 
 
-COMMAND="python -c \"from datadayessentials.config import config; config_manager=config(); config_manager.set_default_variables()\""
+COMMAND="python -c \"from datadayessentials.config import Config; config_manager=Config(); config_manager.set_default_variables()\""
 eval "$COMMAND"
 
 

--- a/databricks/general_cluster_setup.sh
+++ b/databricks/general_cluster_setup.sh
@@ -7,20 +7,16 @@ sudo ACCEPT_EULA=Y apt-get -q -y install msodbcsql17
 pip install --upgrade pip
 TOKEN="$(</dbfs/Shared/dbx/cluster_init_scripts/core_token.txt)"
 AZURE_ENVIRONMENT_NAME="$(</dbfs/Shared/dbx/cluster_init_scripts/azure_environment_name.txt)"
-AZURE_SUBSCRIPTION_ID="$(</dbfs/Shared/dbx/cluster_init_scripts/azure_subscription_id.txt)"
-AZURE_RESOURCE_GROUP="$(</dbfs/Shared/dbx/cluster_init_scripts/azure_resource_group.txt)"
-AZURE_ML_WORKSPACE="$(</dbfs/Shared/dbx/cluster_init_scripts/azure_ml_workspace.txt)"
-AZURE_DATA_LAKE="$(</dbfs/Shared/dbx/cluster_init_scripts/azure_data_lake.txt)"
-export AZURE_TENANT_ID="$(</dbfs/Shared/dbx/cluster_init_scripts/azure_tenant_id.txt)"
-export AZURE_CLIENT_SECRET="$(</dbfs/Shared/dbx/cluster_init_scripts/azure_client_secret.txt)"
-export AZURE_CLIENT_ID="$(</dbfs/Shared/dbx/cluster_init_scripts/azure_client_id.txt)"
+export AZURE_APP_CONFIG_CONNECTION_STRING="$(</dbfs/Shared/dbx/cluster_init_scripts/azure_app_config_connection_string.txt)"
+
+
 
 # Install Core
 COMMAND="pip install git+https://$TOKEN@github.com/Carfinance247/datadayessentials.git"
 eval "$COMMAND"
 
-# Initialise Core
-COMMAND="python -c \"from datadayessentials import initialise_core_config; initialise_core_config(environment_name='$AZURE_ENVIRONMENT_NAME', subscription_id='$AZURE_SUBSCRIPTION_ID', resource_group='$AZURE_RESOURCE_GROUP', machine_learning_workspace='$AZURE_ML_WORKSPACE', data_lake='$AZURE_DATA_LAKE', tenant_id='$AZURE_TENANT_ID', create_new_config=False)\""
+
+COMMAND="python -c \"from datadayessentials.config import config; config_manager=config(); config_manager.set_default_variables()\""
 eval "$COMMAND"
 
 

--- a/datadayessentials/config/global_config.yml
+++ b/datadayessentials/config/global_config.yml
@@ -1,1 +1,0 @@
-local_cache_dir: ".core_cache"


### PR DESCRIPTION
1. removed env variable reference in the CI yaml.  These will now be obtained when essentials config runs the set_env variables code
2. added the connection string to azure app configuration
3. added an app configuration resource to the data-day-science account and populated it
4. updated the cluster setup script and exported the connection string to app config to the databricks cluster